### PR TITLE
Fix VLC's compilation shell script for simulator builds on 64 bit Macs

### DIFF
--- a/projects/xcode4/upnpx/upnpx.xcodeproj/project.pbxproj
+++ b/projects/xcode4/upnpx/upnpx.xcodeproj/project.pbxproj
@@ -941,7 +941,7 @@
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				USER_HEADER_SEARCH_PATHS = "../../../src/api ../../../src/port/ios ../../../src/common";
-				VALID_ARCHS = "arm64 armv7 armv7s i386";
+				VALID_ARCHS = "arm64 armv7 armv7s i386 x86_64";
 			};
 			name = Debug;
 		};
@@ -958,7 +958,7 @@
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				USER_HEADER_SEARCH_PATHS = "../../../src/api ../../../src/port/ios ../../../src/common";
-				VALID_ARCHS = "arm64 armv7 armv7s i386";
+				VALID_ARCHS = "arm64 armv7 armv7s i386 x86_64";
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Add x86_64 as a valid architecture in the project for the static library.
