### PR TITLE
Add support for parsing the manufacturerURL and modelURL properties of a device. Fix the parsing of the objectClass property on MediaServerBasicObjectParser

### DIFF
--- a/src/api/BasicDeviceParser.h
+++ b/src/api/BasicDeviceParser.h
@@ -72,10 +72,12 @@
 @property (readwrite, retain) NSString* udn;
 @property (readwrite, retain) NSString* friendlyName;
 @property (readwrite, retain) NSString* manufacturer;
+@property (readwrite, retain) NSString* manufacturerURLString;
 
 @property (nonatomic, retain) NSString *modelDescription;
 @property (nonatomic, retain) NSString *modelName;
 @property (nonatomic, retain) NSString *modelNumber;
+@property (nonatomic, retain) NSString *modelURLString;
 @property (nonatomic, retain) NSString *serialNumber;
 
 @end

--- a/src/api/BasicUPnPDevice.h
+++ b/src/api/BasicUPnPDevice.h
@@ -82,9 +82,13 @@
 @property(readwrite, retain) NSString *baseURLString;
 @property(readwrite, retain) NSString *friendlyName;
 @property (nonatomic, retain) NSString *manufacturer;
+@property (nonatomic, retain) NSURL *manufacturerURL;
+@property (nonatomic, retain) NSString *manufacturerURLString;
 @property (nonatomic, retain) NSString *modelDescription;
 @property (nonatomic, retain) NSString *modelName;
 @property (nonatomic, retain) NSString *modelNumber;
+@property (nonatomic, retain) NSURL *modelURL;
+@property (nonatomic, retain) NSString *modelURLString;
 @property (nonatomic, retain) NSString *serialNumber;
 @property(readwrite, retain) NSString *udn;
 @property(readwrite, retain) NSString *usn;

--- a/src/upnp/BasicDeviceParser.m
+++ b/src/upnp/BasicDeviceParser.m
@@ -49,9 +49,11 @@
 @synthesize udn;
 @synthesize friendlyName;
 @synthesize manufacturer;
+@synthesize manufacturerURLString;
 @synthesize modelDescription;
 @synthesize modelName;
 @synthesize modelNumber;
+@synthesize modelURLString;
 @synthesize serialNumber;
 
 /****
@@ -122,7 +124,10 @@
         [self addAsset:@[@"root", @"device", @"modelDescription"] callfunction:nil functionObject:nil setStringValueFunction:@selector(setModelDescription:) setStringValueObject:self];
         [self addAsset:@[@"root", @"device", @"modelName"] callfunction:nil functionObject:nil setStringValueFunction:@selector(setModelName:) setStringValueObject:self];
         [self addAsset:@[@"root", @"device", @"modelNumber"] callfunction:nil functionObject:nil setStringValueFunction:@selector(setModelNumber:) setStringValueObject:self];
+        [self addAsset:@[@"root", @"device", @"modelURL"] callfunction:nil functionObject:nil setStringValueFunction:@selector(setModelURLString:) setStringValueObject:self];
         [self addAsset:@[@"root", @"device", @"serialNumber"] callfunction:nil functionObject:nil setStringValueFunction:@selector(setSerialNumber:) setStringValueObject:self];
+        [self addAsset:@[@"root", @"device", @"manufacturer"] callfunction:nil functionObject:nil setStringValueFunction:@selector(setManufacturer:) setStringValueObject:self];
+        [self addAsset:@[@"root", @"device", @"manufacturerURL"] callfunction:nil functionObject:nil setStringValueFunction:@selector(setManufacturerURLString:) setStringValueObject:self];
 
         [self addAsset:@[@"root", @"device", @"iconList", @"icon"] callfunction:@selector(iconFound:) functionObject:self setStringValueFunction:nil setStringValueObject:nil];
         [self addAsset:@[@"root", @"device", @"iconList", @"icon", @"mimetype"] callfunction:nil functionObject:nil setStringValueFunction:@selector(setIconMime:) setStringValueObject:self];
@@ -138,6 +143,7 @@
         [self addAsset:@[@"*", @"device", @"deviceList", @"device", @"UDN"] callfunction:nil functionObject:nil setStringValueFunction:@selector(setUdn:) setStringValueObject:self];
         [self addAsset:@[@"*", @"device", @"deviceList", @"device", @"friendlyName"] callfunction:nil functionObject:nil setStringValueFunction:@selector(setFriendlyName:) setStringValueObject:self];
         [self addAsset:@[@"*", @"device", @"deviceList", @"device", @"manufacturer"] callfunction:nil functionObject:nil setStringValueFunction:@selector(setManufacturer:) setStringValueObject:self];
+        [self addAsset:@[@"*", @"device", @"deviceList", @"device", @"manufacturerURL"] callfunction:nil functionObject:nil setStringValueFunction:@selector(setManufacturerURLString:) setStringValueObject:self];
     }
 
     return self;
@@ -154,6 +160,7 @@
     [udn release];
     [friendlyName release];
     [manufacturer release];
+    [manufacturerURLString release];
 
     [friendlyNameStack release];
     [udnStack release];
@@ -161,6 +168,7 @@
     [modelDescription release];
     [modelName release];
     [modelNumber release];
+    [modelURLString release];
     [serialNumber release];
 
     [super dealloc];
@@ -190,6 +198,22 @@
         NSURL *loc = [NSURL URLWithString:[device baseURLString]];
         if(loc != nil){
             [device setBaseURL:loc];
+        }
+    }
+
+    //Manufacturer URL
+    if ([[device manufacturerURLString] length]){
+        NSURL *loc = [NSURL URLWithString:[device manufacturerURLString]];
+        if(loc != nil){
+            [device setManufacturerURL:loc];
+        }
+    }
+    
+    //Model URL
+    if ([[device modelURLString] length]){
+        NSURL *loc = [NSURL URLWithString:[device modelURLString]];
+        if(loc != nil){
+            [device setModelURL:loc];
         }
     }
 
@@ -259,10 +283,12 @@
             [device setUdn:udn];
             [device setFriendlyName:friendlyName];
             [device setManufacturer:manufacturer];
+            [device setManufacturerURLString:manufacturerURLString];
 
             [device setModelDescription:modelDescription];
             [device setModelName:modelName];
             [device setModelNumber:modelNumber];
+            [device setModelURLString:modelURLString];
             [device setSerialNumber:serialNumber];
         }
     }
@@ -281,6 +307,7 @@
                 [device setFriendlyName:friendlyName];
                 [device setUdn:udn];
                 [device setManufacturer:manufacturer];
+                [device setManufacturerURLString:manufacturerURLString];
             }
         }
         [self setUdn:[udnStack lastObject]];

--- a/src/upnp/BasicUPnPDevice.m
+++ b/src/upnp/BasicUPnPDevice.m
@@ -52,6 +52,8 @@
 @synthesize baseURLString;
 @synthesize friendlyName;
 @synthesize manufacturer;
+@synthesize manufacturerURL;
+@synthesize manufacturerURLString;
 @synthesize udn;
 @synthesize usn;
 @synthesize urn;
@@ -64,6 +66,8 @@
 @synthesize modelDescription;
 @synthesize modelName;
 @synthesize modelNumber;
+@synthesize modelURL;
+@synthesize modelURLString;
 @synthesize serialNumber;
 
 
@@ -111,6 +115,10 @@
     [baseURLString release];
     [friendlyName release];
     [manufacturer release];
+    [manufacturerURL release];
+    [manufacturerURLString release];
+    [modelURL release];
+    [modelURLString release];
     [udn release];
     [usn release];
     [urn release];

--- a/src/upnp/MediaServerBasicObjectParser.m
+++ b/src/upnp/MediaServerBasicObjectParser.m
@@ -266,6 +266,7 @@
         [media setObjectID:mediaID];
         [media setParentID:parentID];
         [media setTitle:mediaTitle];
+        [media setObjectClass:mediaClass];
         [media setArtist:artist];
         [media setAlbum:album];
         [media setDate:date];


### PR DESCRIPTION
1 bug fix and adding the parsing of 2 more properties. This is for improved HDHomeRun detection and support in VLC for iOS.
