### PR TITLE
Move artist property to Basic Object

### DIFF
--- a/src/api/MediaServer1BasicObject.h
+++ b/src/api/MediaServer1BasicObject.h
@@ -40,6 +40,7 @@
     NSString *objectClass;
     NSString *title;
     NSString *albumArt;
+    NSString *artist;
 
     BOOL isContainer;
 }
@@ -49,6 +50,7 @@
 @property (readwrite, retain)NSString *title;
 @property (readwrite, retain)NSString *objectClass;
 @property (readwrite)BOOL isContainer;
-@property(readwrite, retain) NSString *albumArt;
+@property (readwrite, retain) NSString *albumArt;
+@property (readwrite, retain) NSString *artist;
 
 @end

--- a/src/api/MediaServer1ItemObject.h
+++ b/src/api/MediaServer1ItemObject.h
@@ -36,7 +36,6 @@
 #import "MediaServer1ItemRes.h"
 
 @interface MediaServer1ItemObject : MediaServer1BasicObject {
-    NSString *artist;
     NSString *album;
     NSString *date;
     NSString *genre;
@@ -56,7 +55,6 @@
 
 -(void)addRes:(MediaServer1ItemRes*) res;
 
-@property(retain, nonatomic) NSString *artist;
 @property(retain, nonatomic) NSString *album;
 @property(retain, nonatomic) NSString *date;
 @property(retain, nonatomic) NSString *genre;

--- a/src/upnp/MediaServer1BasicObject.m
+++ b/src/upnp/MediaServer1BasicObject.m
@@ -43,6 +43,7 @@
 @synthesize isContainer;
 @synthesize objectClass;
 @synthesize albumArt;
+@synthesize artist;
 
 -(void)dealloc{
     [objectID release];
@@ -50,6 +51,7 @@
     [title release];
     [objectClass release];
     [albumArt release];
+    [artist release];
 
     [super dealloc];
 }

--- a/src/upnp/MediaServer1ItemObject.m
+++ b/src/upnp/MediaServer1ItemObject.m
@@ -37,7 +37,6 @@
 
 @implementation MediaServer1ItemObject
 
-@synthesize artist;
 @synthesize album;
 @synthesize date;
 @synthesize genre;
@@ -81,7 +80,6 @@
 }
 
 -(void)dealloc{
-    [artist release];
     [album release];
     [date release];
     [genre release];

--- a/src/upnp/MediaServerBasicObjectParser.m
+++ b/src/upnp/MediaServerBasicObjectParser.m
@@ -105,6 +105,7 @@
             [self addAsset:@[@"DIDL-Lite", @"container", @"title"] callfunction:nil functionObject:nil setStringValueFunction:@selector(setMediaTitle:) setStringValueObject:self];
             [self addAsset:@[@"DIDL-Lite", @"container", @"class"] callfunction:nil functionObject:nil setStringValueFunction:@selector(setMediaClass:) setStringValueObject:self];
             [self addAsset:@[@"DIDL-Lite", @"container", @"albumArtURI"] callfunction:nil functionObject:nil setStringValueFunction:@selector(setAlbumArt:) setStringValueObject:self];
+            [self addAsset:@[@"DIDL-Lite", @"container", @"artist"] callfunction:nil functionObject:nil setStringValueFunction:@selector(setArtist:) setStringValueObject:self];
         }
 
 


### PR DESCRIPTION
upnp devices often return the artist property for the
`object.container.album.musicAlbum` class. By
restricting the property to the item level
(`object.item.audioItem.musicTrack`), it makes it awkward to
access this property from the music album folder level.

This patch moves the property up to the Basic Object level so it may be
used earlier.
