### PR TITLE
Add support for multiple resource objects

### DIFF
--- a/src/upnp/BasicParser.m
+++ b/src/upnp/BasicParser.m
@@ -215,6 +215,7 @@ static NSString *ElementStop = @"ElementStop";
     BasicParserAsset* asset = [self getAssetForElementStack:mElementStack];
     if(asset != nil){
         elementAttributeDict = attributeDict;//make temprary available to derived classes
+        [elementAttributeDict retain];
 
         if([asset stringValueFunction] != nil && [asset stringValueObject] != nil){
             //we are interested in a string and we are looking for this
@@ -255,6 +256,8 @@ static NSString *ElementStop = @"ElementStop";
                 [[asset functionObject] performSelector:[asset function] withObject:ElementStop];
             }
         }
+        elementAttributeDict = nil;
+        [elementAttributeDict release];
     }
 
     if([elementName isEqualToString:[mElementStack lastObject]]){


### PR DESCRIPTION
Previously the parser would set attributes based on the last resource
object in the resource array. This was problematic with certain older
UPnP servers which declared thumbnails as resource object.

This patch means that uri, protocol info and other necessary attributes
are set by the LAST resource object providing the protocol does not
contain the string "image/".

Fixes #30 
