### PR TITLE
Solve reentrant parsing issue in iOS 8

### DIFF
--- a/src/upnp/BasicParser.m
+++ b/src/upnp/BasicParser.m
@@ -175,23 +175,12 @@ static NSString *ElementStop = @"ElementStop";
     if(parser == nil){
         return -1;
     }
-    
-    // iOS 8 changes behaviour based on reentrant parsing, requiring a 
-    // synchronous workaround.
-    // https://devforums.apple.com/message/1028271
-    __block BOOL pret;
-    dispatch_queue_t reentrantAvoidanceQueue = dispatch_queue_create("reentrantAvoidanceQueue", DISPATCH_QUEUE_SERIAL);
-    dispatch_async(reentrantAvoidanceQueue, ^{
 
-        [parser setShouldProcessNamespaces:mSupportNamespaces];
-        [parser setDelegate:self];
+    [parser setShouldProcessNamespaces:mSupportNamespaces];
+    [parser setDelegate:self];
 
-        pret = [parser parse];
-        [parser setDelegate:nil];
-            
-    });
-    
-    dispatch_sync(reentrantAvoidanceQueue, ^{ });
+    BOOL pret = [parser parse];
+    [parser setDelegate:nil];
 
     return pret? 0: -1;
 }


### PR DESCRIPTION
Commit 52fc4be had the right approach, but the reentrance avoidance code
was in the wrong place. It should have have been added when the
reentrant parser was created.

This commit fixes the reentrant issue, also fixes #26.
