### PR TITLE
Fix unsubscribe crash

### DIFF
--- a/src/upnp/UPnPEvents.m
+++ b/src/upnp/UPnPEvents.m
@@ -156,6 +156,9 @@
 }
 
 -(void)UnSubscribe:(NSString*)uuid{
+    if (!uuid) {
+        return;
+    }
     [mMutex lock];
     [mEventSubscribers removeObjectForKey:uuid];
     [mMutex unlock];


### PR DESCRIPTION
Attempting to remove a nil key results in a crash. If a nil object passed in, return early.