### PR TITLE
Dont unsubscribe if old and new UUID are the same

### DIFF
--- a/src/upnp/BasicUPnPService.m
+++ b/src/upnp/BasicUPnPService.m
@@ -223,7 +223,9 @@
         if(eventUUID != nil){
             //NSLog(@"Service Re-Subsrcibed for events;uuid:%@, old uuid:%@", eventUUID, oldUUID);
             //Unsubscribe old
-            [[[UPnPManager GetInstance] upnpEvents] UnSubscribe:oldUUID];
+            if (![eventUUID isEqual:oldUUID]) {
+                [[[UPnPManager GetInstance] upnpEvents] UnSubscribe:oldUUID];
+            }
             [oldUUID release];
             [eventUUID retain];
             isSupportForEvents = YES;


### PR DESCRIPTION
When event subscriptions are due to time out, UPnPEvents automatically renews them. The problem is if the old UUID is equal to the UUID returned by the renderer, then the observer is instantly unsubscribed.

Closes #42