### PR TITLE
Enable compatibility with CocoaPods 0.36 and support for adding pod as a framework.

### DIFF
--- a/upnpx.podspec
+++ b/upnpx.podspec
@@ -12,6 +12,8 @@ Pod::Spec.new do |s|
 
   s.ios.source_files =  'src/{api,common,eventserver,ssdp,upnp}/*.{h,m,mm,c,cpp}', 'src/port/ios/*.{h,m}'
   s.osx.source_files =  'src/{api,common,eventserver,ssdp,upnp}/*.{h,m,mm,c,cpp}', 'src/port/macos/*.{h,m}'
+  s.ios.public_header_files = 'src/api/*.h', 'src/port/ios/*.h'
+  s.osx.public_header_files = 'src/api/*.h', 'src/port/macos/*.h'
   s.library          = 'stdc++'
   s.xcconfig = {
        'CLANG_CXX_LANGUAGE_STANDARD' => 'c++0x',


### PR DESCRIPTION
This is done by simply exposing only the public, non-C++ headers. For some reason the compiler kept compiling the C++ headers as if they were Objective-C/C headers and reporting errors when adding this pod as a framework using CocoaPods 0.36 Beta. NOTE: This modification will prevent exposure of all the C++ classes however I don't believe they were meant to be public. See "About Public Headers" section here: http://blog.cocoapods.org/Pod-Authors-Guide-to-CocoaPods-Frameworks/