### PR TITLE
iOS returns status code = 0 on timeout, therefore 'ret' contains a misle...

### DIFF
--- a/src/upnp/SoapAction.m
+++ b/src/upnp/SoapAction.m
@@ -129,6 +129,7 @@
         NSString *rsp = [[NSString  alloc] initWithData:resp encoding:NSUTF8StringEncoding];
         NSLog(@"Error (SoapAction): Got a non 200 response: %ld. Data: %@", (long)[urlResponse statusCode], rsp);
         [rsp release];
+        if (ret == 0) ret = -408;
     }else{
         ret = 0;
     }


### PR DESCRIPTION
iOS returns status code = 0 on timeout, therefore 'ret' contains a misleading value '0' in that case.
Fixed by setting an error -408 in such a case, to be double checked.