### PR TITLE
Basic parser leak fixes

### DIFF
--- a/src/upnp/BasicParser.m
+++ b/src/upnp/BasicParser.m
@@ -95,8 +95,8 @@ static NSString *ElementStop = @"ElementStop";
     NSArray *assets;
 
     @synchronized (self) {
-        elementStack = [stack copy];
-        assets = [mAssets copy];
+        elementStack = [[stack copy] autorelease];
+        assets = [[mAssets copy] autorelease];
     }
     NSEnumerator *enumer = [assets objectEnumerator];
     while((asset = [enumer nextObject])){
@@ -165,6 +165,7 @@ static NSString *ElementStop = @"ElementStop";
             NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"^\\s*$\\r?\\n" options:NSRegularExpressionAnchorsMatchLines error:&error];
             xml = [regex stringByReplacingMatchesInString:xml options:0 range:NSMakeRange(0, [xml length]) withTemplate:@""];
             data = [xml dataUsingEncoding:NSUTF8StringEncoding];
+            [xml release];
         }
         NSXMLParser *parser = [[NSXMLParser alloc] initWithData:data];
         int ret = [self startParser:parser];
@@ -187,6 +188,7 @@ static NSString *ElementStop = @"ElementStop";
             NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"^\\s*$\\r?\\n" options:NSRegularExpressionAnchorsMatchLines error:&error];
             xml = [regex stringByReplacingMatchesInString:xml options:0 range:NSMakeRange(0, [xml length]) withTemplate:@""];
             data = [xml dataUsingEncoding:NSUTF8StringEncoding];
+            [xml release];
         }
         NSXMLParser *parser = [[NSXMLParser alloc] initWithData:data];
         int ret = [self startParser:parser];

--- a/src/upnp/BasicParser.m
+++ b/src/upnp/BasicParser.m
@@ -160,12 +160,11 @@ static NSString *ElementStop = @"ElementStop";
 -(int)parseFromData:(NSData*)data{
     @autoreleasepool {
         if (data != nil) {
-            NSString *xml = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+            NSString *xml = [[[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding] autorelease];
             NSError *error = NULL;
             NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"^\\s*$\\r?\\n" options:NSRegularExpressionAnchorsMatchLines error:&error];
             xml = [regex stringByReplacingMatchesInString:xml options:0 range:NSMakeRange(0, [xml length]) withTemplate:@""];
             data = [xml dataUsingEncoding:NSUTF8StringEncoding];
-            [xml release];
         }
         NSXMLParser *parser = [[NSXMLParser alloc] initWithData:data];
         int ret = [self startParser:parser];
@@ -183,12 +182,11 @@ static NSString *ElementStop = @"ElementStop";
 
         NSData *data = [NSData dataWithContentsOfURL:url];
         if (data != nil) {
-            NSString *xml = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+            NSString *xml = [[[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding] autorelease];
             NSError *error = NULL;
             NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"^\\s*$\\r?\\n" options:NSRegularExpressionAnchorsMatchLines error:&error];
             xml = [regex stringByReplacingMatchesInString:xml options:0 range:NSMakeRange(0, [xml length]) withTemplate:@""];
             data = [xml dataUsingEncoding:NSUTF8StringEncoding];
-            [xml release];
         }
         NSXMLParser *parser = [[NSXMLParser alloc] initWithData:data];
         int ret = [self startParser:parser];


### PR DESCRIPTION
Here is my proposed fix for https://github.com/fkuehne/upnpx/issues/64. I used autoreleases for the two strings because the local ```xml``` variable is reused with stringByReplacingMatchesInString so I can't just put a ```[xml release];``` at the end.