### PR TITLE
socketserver: Remove unused write-related code in ReadLoop

### DIFF
--- a/src/eventserver/socketserver.h
+++ b/src/eventserver/socketserver.h
@@ -71,7 +71,6 @@ private:
     pthread_t mReadThread;
     fd_set mExceptionFDS;
     fd_set mReadFDS;
-    fd_set mWriteFDS;
 
     int mMaxConnections;
 


### PR DESCRIPTION
This will prevent high CPU usage leading to the app being killed by the system on iOS.

Write-related code was introduced by c9094c1 as a fix for high CPU usage,
which was probably actually caused by the missing timeout reassignation in
the loop.
