### PR TITLE
close socketserver socket by stop

### DIFF
--- a/src/eventserver/socketserver.cpp
+++ b/src/eventserver/socketserver.cpp
@@ -59,7 +59,7 @@
 #define IFF_ALLMULTI    0x200           /* receive all multicast packets*/
 
 
-SocketServer::SocketServer(unsigned short preferredPort):mServerSocket(NULL),mReadLoop(0){
+SocketServer::SocketServer(unsigned short preferredPort):mServerSocket(INVALID_SOCKET),mReadLoop(0){
     mPort = preferredPort;
     mMaxConnections = 20;
     memset(ipAddress, 0, sizeof(ipAddress));
@@ -135,6 +135,10 @@ int SocketServer::Start(){
     u32 optval = 0;
     int cnt = 0;
 
+    if (mServerSocket != INVALID_SOCKET) {
+        ret = -9;
+        goto EXIT;
+    }
     //Get the IP Address
     ret = getLocalIPAddress(ipAddress, 10);
     if(ret != 0){
@@ -200,7 +204,12 @@ EXIT:
 
 
 int SocketServer::Stop(){
-    return -1;
+    if (mServerSocket > 0) {
+        close(mServerSocket);
+        mServerSocket = INVALID_SOCKET;
+        mReadLoop = 0;
+    }
+    return 0;
 }
 
 

--- a/src/eventserver/socketserver.cpp
+++ b/src/eventserver/socketserver.cpp
@@ -295,6 +295,10 @@ int SocketServer::ReadLoop(){
                 if(mConnections.size() <= mMaxConnections){
                     senderlen = sizeof(struct sockaddr);
                     SOCKET newSocket = accept(mServerSocket, (sockaddr*)&sender, &senderlen);
+		    if (newSocket < 0) {
+                        printf("accpet failed %d %d\n", errno, EFAULT);
+                        break;
+                    }
                     SocketServerConnection* newConnection = new SocketServerConnection(newSocket, &sender);
                     mConnections.push_back(newConnection);
                 }else{

--- a/src/upnp/UPnPEvents.m
+++ b/src/upnp/UPnPEvents.m
@@ -78,12 +78,14 @@ static NSUInteger const kEventSubscriptionTimeoutInSeconds = 1800;
     //Start the subscription timer
     mTimeoutTimer = [NSTimer timerWithTimeInterval:60.0 target:self selector:@selector(manageSubscriptionTimeouts:) userInfo:nil repeats:YES];
     [[NSRunLoop currentRunLoop] addTimer:mTimeoutTimer forMode:NSDefaultRunLoopMode];
+    [server start];
 }
 
 - (void)stop {
     //Stop the subscription timer
     [mTimeoutTimer invalidate];
     mTimeoutTimer = nil;
+    [server stop];
 }
 
 -(void)subscribe:(id<UPnPEvents_Observer>)subscriber completion:(void (^)(NSString * __nullable uuid))completion {


### PR DESCRIPTION
ios will close all sockets after screen off

if it is not safe to keep socket liston and causes high cpu usage.
so fix it.

Signed-off-by: Janboe Ye <janboe.ye@outlook.com>