### PR TITLE
Closes #75

### DIFF
--- a/src/api/BasicUPnPService.h
+++ b/src/api/BasicUPnPService.h
@@ -68,6 +68,7 @@
     NSString *eventUUID;
 
     NSMutableDictionary<NSString *, StateVariable *> *stateVariables;
+    NSMutableDictionary *currentStateVariableValues;
     NSMutableArray<BasicUPnPServiceObserver> *mObservers;
 
     NSRecursiveLock *mMutex;
@@ -81,6 +82,7 @@
 @property (readwrite, retain) NSString *serviceType;
 @property (readonly, retain) SSDPDBDevice_ObjC *ssdpdevice;
 @property (readonly) NSMutableDictionary *stateVariables;
+@property (readonly) NSMutableDictionary *currentStateVariableValues;
 @property (readonly) SoapAction *soap;
 @property (readwrite, retain) NSString *urn;
 @property (readwrite) BOOL isSetUp;

--- a/src/api/UPnPEvents.h
+++ b/src/api/UPnPEvents.h
@@ -60,9 +60,23 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+@interface BufferedEvent : NSObject{
+    double eventTime;
+    NSString* subscriptionID;
+    NSDictionary *events;
+}
+
+@property (readwrite) double eventTime;
+@property (readwrite, strong) NSString* subscriptionID;
+@property (readwrite, strong) NSDictionary *events;
+
+@end
+
+
 
 @interface UPnPEvents : NSObject <BasicHTTPServer_ObjC_Observer> {
     NSMutableDictionary *mEventSubscribers;//uuid, observer
+    NSMutableArray *mArrivedEventsBuffers; //uuid, list of events
     BasicHTTPServer_ObjC *server;
     UPnPEventParser *parser;
     NSRecursiveLock *mMutex;

--- a/src/upnp/BasicUPnPService.m
+++ b/src/upnp/BasicUPnPService.m
@@ -47,6 +47,7 @@
 @synthesize controlURL;
 @synthesize ssdpdevice;
 @synthesize stateVariables;
+@synthesize currentStateVariableValues;
 @synthesize urn;
 @synthesize soap;
 @synthesize isSetUp;
@@ -76,6 +77,8 @@
         isSubscribedForEvents = NO;
 
         stateVariables = [[NSMutableDictionary alloc] init];
+        currentStateVariableValues = [[NSMutableDictionary alloc] init];
+
 
         mObservers = [[NSMutableArray<BasicUPnPServiceObserver> alloc] init];
 
@@ -101,6 +104,7 @@
     [baseURLString release];
 
     [stateVariables release];
+    [currentStateVariableValues release];
 
     [urn release];
     [soap release];
@@ -125,6 +129,11 @@
     [mMutex lock];
     [mObservers addObject:obs];
     ret = [mObservers count];
+    
+    // a new observer should get current state (if we've received some state already)
+    if ([currentStateVariableValues count]>0) {
+        [obs basicUPnPService:self receivedEvents:currentStateVariableValues];
+    }
     [mMutex unlock];
 
     return ret;
@@ -233,6 +242,7 @@
     BasicUPnPServiceObserver *obs = nil;
     
     [mMutex lock];
+    [currentStateVariableValues addEntriesFromDictionary:events];
     NSEnumerator *listeners = [mObservers objectEnumerator];
     while (obs = [listeners nextObject]) {
         [obs basicUPnPService:self receivedEvents:events];


### PR DESCRIPTION
this pull request, changes two things that can lead to 'lost' events: 

- race condition, when we subscribe to events. Some events can arrive 'early', so we buffer all arrived events
- race condition, when we add an observer. the subscription that happens before we add an observer could have received events already, to we keep the current state. When an observer is added, when there is known state already it gets an instant notification. 


I got a bit rusty with retain/release before ARC was introduced (my used version of upnpx was already moved to ARC). If you review this pull request, please have a lookout, if I made mistakes with the memory management.

Cheers
Stefan